### PR TITLE
Android screen lifecycle

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/screens/Screen.java
+++ b/android/app/src/main/java/com/reactnativenavigation/screens/Screen.java
@@ -9,6 +9,7 @@ import android.view.Window;
 import android.widget.RelativeLayout;
 
 import com.facebook.react.bridge.Callback;
+import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.animation.VisibilityAnimator;
 import com.reactnativenavigation.events.ContextualMenuHiddenEvent;
 import com.reactnativenavigation.events.Event;
@@ -218,19 +219,27 @@ public abstract class Screen extends RelativeLayout implements Subscriber {
     public abstract void setOnDisplayListener(OnDisplayListener onContentViewDisplayedListener);
 
     public void show() {
+        NavigationApplication.instance.getEventEmitter().sendNavigatorEvent("willAppear", screenParams.getNavigatorEventId());
+        NavigationApplication.instance.getEventEmitter().sendNavigatorEvent("didAppear", screenParams.getNavigatorEventId());
         screenAnimator.show(screenParams.animateScreenTransitions);
     }
 
     public void show(boolean animated) {
+        NavigationApplication.instance.getEventEmitter().sendNavigatorEvent("willAppear", screenParams.getNavigatorEventId());
+        NavigationApplication.instance.getEventEmitter().sendNavigatorEvent("didAppear", screenParams.getNavigatorEventId());
         screenAnimator.show(animated);
     }
 
     public void show(boolean animated, Runnable onAnimationEnd) {
+        NavigationApplication.instance.getEventEmitter().sendNavigatorEvent("willAppear", screenParams.getNavigatorEventId());
+        NavigationApplication.instance.getEventEmitter().sendNavigatorEvent("didAppear", screenParams.getNavigatorEventId());
         setStyle();
         screenAnimator.show(animated, onAnimationEnd);
     }
 
     public void hide(boolean animated, Runnable onAnimatedEnd) {
+        NavigationApplication.instance.getEventEmitter().sendNavigatorEvent("willDisappear", screenParams.getNavigatorEventId());
+        NavigationApplication.instance.getEventEmitter().sendNavigatorEvent("didDisappear", screenParams.getNavigatorEventId());
         screenAnimator.hide(animated, onAnimatedEnd);
     }
 

--- a/android/app/src/main/java/com/reactnativenavigation/screens/ScreenStack.java
+++ b/android/app/src/main/java/com/reactnativenavigation/screens/ScreenStack.java
@@ -117,6 +117,7 @@ public class ScreenStack {
                                           @Nullable final Screen.OnDisplayListener onDisplay) {
         nextScreen.setVisibility(View.INVISIBLE);
         addScreen(nextScreen, layoutParams);
+        NavigationApplication.instance.getEventEmitter().sendNavigatorEvent("willDisappear", previousScreen.getNavigatorEventId());
         nextScreen.setOnDisplayListener(new Screen.OnDisplayListener() {
             @Override
             public void onDisplay() {
@@ -124,6 +125,7 @@ public class ScreenStack {
                     @Override
                     public void run() {
                         if (onDisplay != null) onDisplay.onDisplay();
+                        NavigationApplication.instance.getEventEmitter().sendNavigatorEvent("didDisappear", previousScreen.getNavigatorEventId());
                         parent.removeView(previousScreen);
                     }
                 });
@@ -196,6 +198,8 @@ public class ScreenStack {
 
     private void readdPrevious(Screen previous) {
         previous.setVisibility(View.VISIBLE);
+        NavigationApplication.instance.getEventEmitter().sendNavigatorEvent("willAppear", previous.getNavigatorEventId());
+        NavigationApplication.instance.getEventEmitter().sendNavigatorEvent("didAppear", previous.getNavigatorEventId());
         parent.addView(previous, 0);
     }
 
@@ -347,9 +351,13 @@ public class ScreenStack {
         isStackVisible = true;
         stack.peek().setStyle();
         stack.peek().setVisibility(View.VISIBLE);
+        NavigationApplication.instance.getEventEmitter().sendNavigatorEvent("willAppear", stack.peek().getNavigatorEventId());
+        NavigationApplication.instance.getEventEmitter().sendNavigatorEvent("didAppear", stack.peek().getNavigatorEventId());
     }
 
     public void hide() {
+        NavigationApplication.instance.getEventEmitter().sendNavigatorEvent("willDisappear", stack.peek().getNavigatorEventId());
+        NavigationApplication.instance.getEventEmitter().sendNavigatorEvent("didDisappear", stack.peek().getNavigatorEventId());
         isStackVisible = false;
         stack.peek().setVisibility(View.INVISIBLE);
     }


### PR DESCRIPTION
This commit is contains a few changes and enhancements to the PR made by simon:

* Use getEventEmitter instead of sendNavigatorEvent
* Dispatch willDisappear and didDisappear events when pushing screens
* Dispatch willAppear and didAppear events when popping screen